### PR TITLE
Override Gemfile.lock while running tests

### DIFF
--- a/lib/firestarter/app_builder.rb
+++ b/lib/firestarter/app_builder.rb
@@ -316,13 +316,6 @@ end
 
     private
 
-    def override_path_for_tests
-      return unless ENV["TESTING"]
-
-      support_bin = File.expand_path(File.join("..", "..", "spec", "fakes", "bin"))
-      "PATH=#{support_bin}:$PATH"
-    end
-
     def factories_spec_rake_task
       IO.read find_in_source_paths("factories_spec_rake_task.rb")
     end

--- a/lib/firestarter/app_builder.rb
+++ b/lib/firestarter/app_builder.rb
@@ -308,13 +308,19 @@ end
       copy_file "metrics.reek", ".metrics.reek"
     end
 
+    def override_gemfile_lock_for_tests
+      return unless ENV["TESTING"]
+
+      copy_file "test/Gemfile.lock", "Gemfile.lock"
+    end
+
     private
 
     def override_path_for_tests
-      if ENV["TESTING"]
-        support_bin = File.expand_path(File.join("..", "..", "spec", "fakes", "bin"))
-        "PATH=#{support_bin}:$PATH"
-      end
+      return unless ENV["TESTING"]
+
+      support_bin = File.expand_path(File.join("..", "..", "spec", "fakes", "bin"))
+      "PATH=#{support_bin}:$PATH"
     end
 
     def factories_spec_rake_task

--- a/lib/firestarter/generators/app_generator.rb
+++ b/lib/firestarter/generators/app_generator.rb
@@ -42,6 +42,7 @@ module Firestarter
 
     def customize_gemfile
       build :replace_gemfile
+      build :override_gemfile_lock_for_tests
       build :set_ruby_to_version_being_used
     end
 

--- a/spec/support/firestarter.rb
+++ b/spec/support/firestarter.rb
@@ -12,6 +12,7 @@ module FirestarterTestHelpers
   def run_firestarter(arguments = nil)
     Dir.chdir(tmp_path) do
       Bundler.with_clean_env do
+        add_fakes_to_path
         ENV["TESTING"] = "1"
 
         `bundle exec #{firestarter_bin} #{APP_NAME} #{arguments}`
@@ -45,12 +46,20 @@ module FirestarterTestHelpers
 
   private
 
+  def add_fakes_to_path
+    ENV["PATH"] = "#{support_bin}:#{ENV['PATH']}"
+  end
+
   def tmp_path
     @tmp_path ||= Pathname.new("#{root_path}/tmp")
   end
 
   def firestarter_bin
     File.join(root_path, "bin", "firestarter")
+  end
+
+  def support_bin
+    File.join(root_path, "spec", "fakes", "bin")
   end
 
   def root_path

--- a/templates/test/Gemfile.lock
+++ b/templates/test/Gemfile.lock
@@ -1,0 +1,286 @@
+GIT
+  remote: git://github.com/Mon-Ouie/pry-remote.git
+  revision: f4cc9774816571b4dbe14786592140f54364fb01
+  specs:
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
+
+GIT
+  remote: git://github.com/naps62/retina_tag.git
+  revision: 9389becdf921b512475d36a7797df6733ac87108
+  ref: 9389bec
+  specs:
+    retina_tag (1.3.1)
+      jquery-rails
+      rails (>= 3.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionmailer (4.2.6)
+      actionpack (= 4.2.6)
+      actionview (= 4.2.6)
+      activejob (= 4.2.6)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (4.2.6)
+      actionview (= 4.2.6)
+      activesupport (= 4.2.6)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.6)
+      activesupport (= 4.2.6)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (4.2.6)
+      activesupport (= 4.2.6)
+      globalid (>= 0.3.0)
+    activemodel (4.2.6)
+      activesupport (= 4.2.6)
+      builder (~> 3.1)
+    activerecord (4.2.6)
+      activemodel (= 4.2.6)
+      activesupport (= 4.2.6)
+      arel (~> 6.0)
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
+    arel (6.0.3)
+    ast (2.3.0)
+    bcrypt (3.1.11)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
+    builder (3.2.2)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
+    clearance (1.14.1)
+      bcrypt
+      email_validator (~> 1.4)
+      rails (>= 3.1)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
+    debug_inspector (0.0.2)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    email_validator (1.6.0)
+      activemodel
+    erubis (2.7.0)
+    execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
+    globalid (0.3.6)
+      activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
+    i18n (0.7.0)
+    jquery-rails (4.1.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
+    minitest (5.9.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    parser (2.3.1.2)
+      ast (~> 2.2)
+    pg (0.18.4)
+    pkg-config (1.1.7)
+    powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    puma (3.4.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
+    rack (1.6.4)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rack-timeout (0.4.2)
+    rails (4.2.6)
+      actionmailer (= 4.2.6)
+      actionpack (= 4.2.6)
+      actionview (= 4.2.6)
+      activejob (= 4.2.6)
+      activemodel (= 4.2.6)
+      activerecord (= 4.2.6)
+      activesupport (= 4.2.6)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.2.6)
+      sprockets-rails
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.7)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
+    railties (4.2.6)
+      actionpack (= 4.2.6)
+      activesupport (= 4.2.6)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
+    rake (11.2.2)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-rails (3.4.2)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    rubocop (0.40.0)
+      parser (>= 2.3.1.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+    sass-rails (5.0.4)
+      railties (>= 4.0.0, < 5.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
+    scss_lint (0.48.0)
+      rake (>= 0.9, < 12)
+      sass (~> 3.4.15)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    slim (3.0.7)
+      temple (~> 0.7.6)
+      tilt (>= 1.3.3, < 2.1)
+    slim-rails (3.1.0)
+      actionpack (>= 3.1)
+      railties (>= 3.1)
+      slim (~> 3.0)
+    slop (3.6.0)
+    spring (1.7.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
+    sprockets (3.6.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    temple (0.7.7)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
+    timecop (0.8.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.0.5)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  better_errors
+  binding_of_caller
+  capybara
+  capybara-webkit
+  clearance
+  database_cleaner
+  factory_girl_rails
+  foreman
+  jquery-rails
+  letter_opener
+  pg
+  pry-rails
+  pry-remote!
+  puma
+  quiet_assets
+  rack-timeout
+  rails (~> 4.2.0)
+  rails_12factor
+  retina_tag!
+  rspec-rails (~> 3.0)
+  rubocop
+  sass-rails
+  scss_lint
+  simplecov
+  slim-rails
+  spring
+  spring-commands-rspec
+  timecop
+  uglifier
+  webmock
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Why:
- When running the tests, a new app is generated, and `bundle install`
  needs to resolve dependencies from scratch.
  If a predefined Gemfile.lock exists, `bundler` will only need to check
  if the specified versions exist (and install the ones that don't),
  instead of taking forever to ask rubygems for this info.
