### PR TITLE
Remove quiet_assets gem

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -17,7 +17,6 @@ group :development do
   gem "better_errors"
   gem "binding_of_caller"
   gem "letter_opener"
-  gem "quiet_assets"
   gem "spring", require: false
   gem "spring-commands-rspec", require: false
 end


### PR DESCRIPTION
Why:

* The quiet_assets gem has been deprecated in favor of configuring
  Sprockets directly.

This change addresses the need by:

* Removing the gem from the template Gemfile;
* Refactoring the template development environment configuration to
  suppress assets generation from the logs (overridable through the
  environment).

Fixes #23